### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Robson/coloring/security/code-scanning/1](https://github.com/Adam-Robson/coloring/security/code-scanning/1)

To fix the problem, add a `permissions` block at the root level of the workflow (before `jobs:`). For CI workflows that only build, lint, and test, `contents: read` is sufficient. This minimizes the risk of privilege escalation by restricting the `GITHUB_TOKEN` to only read repository contents. The change should be made in `.github/workflows/node.js.yml`, above or below the `name:` and before the `jobs:` block. No other changes or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
